### PR TITLE
docs: add clarifying docstring for ProtocalVersion typo

### DIFF
--- a/src/x402_mock/schemas/versions.py
+++ b/src/x402_mock/schemas/versions.py
@@ -2,6 +2,13 @@ from enum import Enum
 from typing import List
 
 class ProtocalVersion(Enum):
+    """
+    Protocol version enumeration.
+    
+    Note: The class name contains a typo ('Protocal' instead of 'Protocol').
+    This is kept as-is for backward compatibility with existing code.
+    See: https://github.com/OpenPayhub/x402-mock/issues
+    """
     Version0_1 = "Version 0.1"
     
     @classmethod


### PR DESCRIPTION
## Summary

Adds a clarifying docstring to the <code>ProtocalVersion</code> class explaining that the class name contains a typo (&quot;Protocal&quot; instead of &quot;Protocol&quot;) but is intentionally kept as-is for backward compatibility.

## Problem

New contributors may be confused by the typo in <code>ProtocalVersion</code> throughout the codebase. The http_client.py already has a comment acknowledging this, but the class definition itself lacked documentation.

## Solution

Added a docstring to the class that:
- Explains the typo exists
- Clarifies it's kept for backward compatibility  
- References the GitHub issues page for context

## Files Changed

- <code>src/x402_mock/schemas/versions.py</code>: Added clarifying docstring

## Type of Change

- [x] Documentation improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change